### PR TITLE
Remove measurements from the code

### DIFF
--- a/Block.cpp
+++ b/Block.cpp
@@ -1,5 +1,4 @@
 #include "Block.h"
-#include <chrono>
 
 namespace BWEB
 {
@@ -57,7 +56,6 @@ namespace BWEB
 
 	void Map::findBlocks()
 	{
-		const auto start = chrono::high_resolution_clock::now();
 		findStartBlock();
 		map<const BWEM::Area *, int> typePerArea;
 
@@ -130,9 +128,6 @@ namespace BWEB
 				}
 			}
 		}
-
-		const auto dur = std::chrono::duration <double, std::milli>(std::chrono::high_resolution_clock::now() - start).count();
-		Broodwar << "Block time:" << dur << endl;
 	}
 
 	bool Map::canAddBlock(const TilePosition here, const int width, const int height, const bool lowReq)

--- a/Station.cpp
+++ b/Station.cpp
@@ -1,5 +1,4 @@
 #include "Station.h"
-#include <chrono>
 
 namespace BWEB
 {
@@ -12,8 +11,6 @@ namespace BWEB
 
 	void Map::findStations()
 	{
-		const auto start = chrono::steady_clock::now();
-
 		for (auto& area : BWEM::Map::Instance().Areas())
 		{
 			for (auto& base : area.Bases())
@@ -50,9 +47,6 @@ namespace BWEB
 				addOverlap(base.Location(), 4, 3);
 			}
 		}
-
-		const auto dur = chrono::duration <double, milli>(chrono::steady_clock::now() - start).count();
-		Broodwar << "Station time: " << dur << endl;
 	}
 
 	set<TilePosition>& Map::stationDefenses(const TilePosition here, const bool mirrorHorizontal, const bool mirrorVertical)

--- a/Wall.cpp
+++ b/Wall.cpp
@@ -1,7 +1,6 @@
 #include "Wall.h"
 #include "AStar.h"
 #include <tuple>
-#include <chrono>
 
 namespace BWEB
 {

--- a/Wall.cpp
+++ b/Wall.cpp
@@ -17,9 +17,6 @@ namespace BWEB
 		if (!area || !choke || buildings.empty())
 			return;
 
-		// Start a clock to time walls
-		const auto start = chrono::steady_clock::now();
-
 		// I got sick of passing the parameters everywhere, sue me
 		this->buildings = buildings, this->area = area, this->choke = choke, this->tight = tight, this->reservePath = reservePath;
 
@@ -64,10 +61,6 @@ namespace BWEB
 
 		// Push wall into the vector
 		walls.push_back(newWall);
-
-		// Print time
-		const auto dur = chrono::duration <double, milli>(chrono::steady_clock::now() - start).count();
-		Broodwar << "Wall time: " << dur << endl;
 	}
 
 	bool Map::iteratePieces()


### PR DESCRIPTION
The measurements done in such way, that it could be
easily done outside of the library code. The actual output to Brodwar variable
make code depends on the BWAPI which complicated testing and possible
porting to other games, for example for SC2. If you want to
have time measurements as part of library, I propose have separate methods
which indicate on measurement to be done.
For example `findBlocksWithTiming` would be used in code, but main code which
do the work will be dependency free.

This is one of proposal to https://github.com/Cmccrave/BWEB/issues/11
