### PR TITLE
Allow have multiple instances of BWEB

### DIFF
--- a/AStar.cpp
+++ b/AStar.cpp
@@ -25,7 +25,7 @@ namespace BWEB
 		};
 	}
 
-	vector<TilePosition> AStar::findPath(const TilePosition source, const TilePosition target, bool walling)
+	vector<TilePosition> AStar::findPath(BWEM::Map& bwem, BWEB::Map& map, const TilePosition source, const TilePosition target, bool walling)
 	{
 		Node *current = nullptr;
 		set<Node*> openSet, closedSet;
@@ -51,9 +51,9 @@ namespace BWEB
 				auto tile(current->coordinates + direction[i]);
 
 				// Detection collision or skip tiles already added to closed set
-				if (!tile.isValid() || BWEB::Map::Instance().overlapGrid[tile.x][tile.y] > 0 || !BWEB::Map::isWalkable(tile) || findNodeOnList(closedSet, tile)) continue;
-				if (BWEB::Map::Instance().overlapsCurrentWall(tile) != UnitTypes::None) continue;
-				if (BWEM::Map::Instance().GetArea(tile) && BWEM::Map::Instance().GetArea(tile) != BWEM::Map::Instance().GetArea(source) && BWEM::Map::Instance().GetArea(tile) != BWEM::Map::Instance().GetArea(target)) continue;
+				if (!tile.isValid() || map.overlapGrid[tile.x][tile.y] > 0 || !BWEB::Map::isWalkable(tile) || findNodeOnList(closedSet, tile)) continue;
+				if (map.overlapsCurrentWall(tile) != UnitTypes::None) continue;
+				if (bwem.GetArea(tile) && bwem.GetArea(tile) != bwem.GetArea(source) && bwem.GetArea(tile) != bwem.GetArea(target)) continue;
 
 				// Cost function?
 				const auto totalCost = current->G + ((i < 4) ? 10 : 14);

--- a/AStar.h
+++ b/AStar.h
@@ -27,6 +27,6 @@ namespace BWEB
 
 	public:
 		AStar();
-		vector<TilePosition> findPath(TilePosition, TilePosition, bool);
+		vector<TilePosition> findPath(BWEM::Map&, BWEB::Map&, TilePosition, TilePosition, bool);
 	};
 }

--- a/BWEB.cpp
+++ b/BWEB.cpp
@@ -19,6 +19,11 @@
 
 namespace BWEB
 {
+	Map::Map(BWEM::Map& map)
+		: map(map)
+	{
+	}
+
 	void Map::onStart()
 	{
 		findMain();
@@ -77,13 +82,13 @@ namespace BWEB
 	{
 		mainTile = Broodwar->self()->getStartLocation();
 		mainPosition = static_cast<Position>(mainTile) + Position(64, 48);
-		mainArea = BWEM::Map::Instance().GetArea(mainTile);
+		mainArea = map.GetArea(mainTile);
 	}
 
 	void Map::findNatural()
 	{
 		auto distBest = DBL_MAX;
-		for (auto& area : BWEM::Map::Instance().Areas())
+		for (auto& area : map.Areas())
 		{
 			for (auto& base : area.Bases())
 			{
@@ -114,7 +119,7 @@ namespace BWEB
 	void Map::findNaturalChoke()
 	{
 		// Exception for maps with a natural behind the main such as Crossing Fields
-		if (getGroundDistance(mainPosition, BWEM::Map::Instance().Center()) < getGroundDistance(Position(naturalTile), BWEM::Map::Instance().Center()))
+		if (getGroundDistance(mainPosition, map.Center()) < getGroundDistance(Position(naturalTile), map.Center()))
 		{
 			naturalChoke = mainChoke;
 			return;
@@ -126,7 +131,7 @@ namespace BWEB
 		for (auto& area : naturalArea->AccessibleNeighbours())
 		{
 			auto center = area->Top();
-			const auto dist = Position(center).getDistance(BWEM::Map::Instance().Center());
+			const auto dist = Position(center).getDistance(map.Center());
 			if (center.isValid() && dist < distBest)
 				second = area, distBest = dist;
 		}
@@ -197,10 +202,10 @@ namespace BWEB
 	double Map::getGroundDistance(PositionType start, PositionType end)
 	{
 		auto dist = 0.0;
-		if (!start.isValid() || !end.isValid() || !BWEM::Map::Instance().GetArea(WalkPosition(start)) || !BWEM::Map::Instance().GetArea(WalkPosition(end)))
+		if (!start.isValid() || !end.isValid() || !map.GetArea(WalkPosition(start)) || !map.GetArea(WalkPosition(end)))
 			return DBL_MAX;
 
-		for (auto& cpp : BWEM::Map::Instance().GetPath(start, end))
+		for (auto& cpp : map.GetPath(start, end))
 		{
 			auto center = Position{ cpp->Center() };
 			dist += start.getDistance(center);
@@ -266,7 +271,7 @@ namespace BWEB
 
 	Map & Map::Instance()
 	{
-		if (!BWEBInstance) BWEBInstance = new Map();
+		if (!BWEBInstance) BWEBInstance = new Map(BWEM::Map::Instance());
 		return *BWEBInstance;
 	}
 }

--- a/BWEB.h
+++ b/BWEB.h
@@ -59,6 +59,7 @@ namespace BWEB
 		vector<UnitType> buildings;
 		const BWEM::ChokePoint * choke{};
 		const BWEM::Area * area{};
+		BWEM::Map& map;
 		UnitType tight;
 		bool reservePath{};
 
@@ -92,6 +93,7 @@ namespace BWEB
 		static Map* BWEBInstance;
 
 	public:
+		Map(BWEM::Map& map = BWEM::Map::Instance());
 		void draw(), onStart(), onUnitDiscover(Unit), onUnitDestroy(Unit), onUnitMorph(Unit);
 		static Map &Instance();
 		int overlapGrid[256][256] = {};
@@ -100,14 +102,14 @@ namespace BWEB
 		/// This is just put here so AStar can use it for now
 		UnitType overlapsCurrentWall(TilePosition tile, int width = 1, int height = 1);
 
-		static bool overlapsBlocks(TilePosition);
-		static bool overlapsStations(TilePosition);
-		static bool overlapsNeutrals(TilePosition);
-		static bool overlapsMining(TilePosition);
-		static bool overlapsWalls(TilePosition);
+		bool overlapsBlocks(TilePosition);
+		bool overlapsStations(TilePosition);
+		bool overlapsNeutrals(TilePosition);
+		bool overlapsMining(TilePosition);
+		bool overlapsWalls(TilePosition);
 		bool overlapsAnything(TilePosition here, int width = 1, int height = 1, bool ignoreBlocks = false);
 		static bool isWalkable(TilePosition);
-		static int tilesWithinArea(BWEM::Area const *, TilePosition here, int width = 1, int height = 1);
+		int tilesWithinArea(BWEM::Area const *, TilePosition here, int width = 1, int height = 1);
 
 		/// <summary> Returns the closest buildable TilePosition for any type of structure </summary>
 		/// <param name="type"> The UnitType of the structure you want to build.</param>
@@ -194,4 +196,18 @@ namespace BWEB
 		/// <summary> Initializes the building of every BWEB::Block on the map, call it only once per game. </summary>
 		void findBlocks();
 	};
+
+	// This namespace contains functions which could be used for backward compatibility
+	// with existing code.
+	// just put using namespace BWEB::Utils in the header and 
+	// replace all usages of Map::overlapsBlocks with just overlapsBlocks
+	namespace Utils
+	{
+		static bool overlapsBlocks(TilePosition);
+		static bool overlapsStations(TilePosition);
+		static bool overlapsNeutrals(TilePosition);
+		static bool overlapsMining(TilePosition);
+		static bool overlapsWalls(TilePosition);
+		static int tilesWithinArea(BWEM::Area const *, TilePosition here, int width = 1, int height = 1);
+	}
 }

--- a/BWEB.h
+++ b/BWEB.h
@@ -93,7 +93,7 @@ namespace BWEB
 		static Map* BWEBInstance;
 
 	public:
-		Map(BWEM::Map& map = BWEM::Map::Instance());
+		Map(BWEM::Map& map);
 		void draw(), onStart(), onUnitDiscover(Unit), onUnitDestroy(Unit), onUnitMorph(Unit);
 		static Map &Instance();
 		int overlapGrid[256][256] = {};

--- a/BWEBUtil.cpp
+++ b/BWEBUtil.cpp
@@ -4,7 +4,7 @@ namespace BWEB
 {
 	bool Map::overlapsStations(const TilePosition here)
 	{
-		for (auto& station : BWEB::Map::Instance().Stations())
+		for (auto& station : Stations())
 		{
 			const auto tile = station.BWEMBase()->Location();
 			if (here.x >= tile.x && here.x < tile.x + 4 && here.y >= tile.y && here.y < tile.y + 3) return true;
@@ -16,7 +16,7 @@ namespace BWEB
 
 	bool Map::overlapsBlocks(const TilePosition here)
 	{
-		for (auto& block : BWEB::Map::Instance().Blocks())
+		for (auto& block : Blocks())
 		{
 			if (here.x >= block.Location().x && here.x < block.Location().x + block.width() && here.y >= block.Location().y && here.y < block.Location().y + block.height()) return true;
 		}
@@ -25,26 +25,26 @@ namespace BWEB
 
 	bool Map::overlapsMining(TilePosition here)
 	{
-		for (auto& station : BWEB::Map::Instance().Stations())
+		for (auto& station : Stations())
 			if (here.getDistance(TilePosition(station.ResourceCentroid())) < 5) return true;
 		return false;
 	}
 
 	bool Map::overlapsNeutrals(const TilePosition here)
 	{
-		for (auto& m : BWEM::Map::Instance().Minerals())
+		for (auto& m : map.Minerals())
 		{
 			const auto tile = m->TopLeft();
 			if (here.x >= tile.x && here.x < tile.x + 2 && here.y >= tile.y && here.y < tile.y + 1) return true;
 		}
 
-		for (auto& g : BWEM::Map::Instance().Geysers())
+		for (auto& g : map.Geysers())
 		{
 			const auto tile = g->TopLeft();
 			if (here.x >= tile.x && here.x < tile.x + 4 && here.y >= tile.y && here.y < tile.y + 2) return true;
 		}
 
-		for (auto& n : BWEM::Map::Instance().StaticBuildings())
+		for (auto& n : map.StaticBuildings())
 		{
 			const auto tile = n->TopLeft();
 			if (here.x >= tile.x && here.x < tile.x + n->Type().tileWidth() && here.y >= tile.y && here.y < tile.y + n->Type().tileHeight()) return true;
@@ -63,7 +63,7 @@ namespace BWEB
 		const auto x = here.x;
 		const auto y = here.y;
 
-		for (auto& wall : Instance().getWalls())
+		for (auto& wall : getWalls())
 		{
 			for (const auto tile : wall.smallTiles())
 				if (x >= tile.x && x < tile.x + 2 && y >= tile.y && y < tile.y + 2) return true;
@@ -114,10 +114,40 @@ namespace BWEB
 			{
 				TilePosition t(x, y);
 				if (!t.isValid()) return false;
-				if (BWEM::Map::Instance().GetArea(t) == area || !BWEM::Map::Instance().GetArea(t))
+				if (map.GetArea(t) == area || !map.GetArea(t))
 					cnt++;
 			}
 		}
 		return cnt;
+	}
+
+	bool Utils::overlapsBlocks(const TilePosition here)
+	{
+		return BWEB::Map::Instance().overlapsBlocks(here);
+	}
+
+	bool Utils::overlapsStations(const TilePosition here)
+	{
+		return BWEB::Map::Instance().overlapsStations(here);
+	}
+
+	bool Utils::overlapsNeutrals(const TilePosition here)
+	{
+		return BWEB::Map::Instance().overlapsNeutrals(here);
+	}
+
+	bool Utils::overlapsMining(TilePosition here)
+	{
+		return BWEB::Map::Instance().overlapsMining(here);
+	}
+
+	bool Utils::overlapsWalls(const TilePosition here)
+	{
+		return BWEB::Map::Instance().overlapsWalls(here);
+	}
+
+	int Utils::tilesWithinArea(BWEM::Area const * area, const TilePosition here, const int width, const int height)
+	{
+		return BWEB::Map::Instance().tilesWithinArea(area, here, width, height);
 	}
 }

--- a/Block.cpp
+++ b/Block.cpp
@@ -41,7 +41,7 @@ namespace BWEB
 			for (auto y = mainTile.y - 30; y <= mainTile.y + 30; y++)
 			{
 				auto tile = TilePosition(x, y);
-				if (!tile.isValid() || BWEM::Map::Instance().GetArea(tile) != mainArea) continue;
+				if (!tile.isValid() || map.GetArea(tile) != mainArea) continue;
 				auto blockCenter = Position(tile) + Position(80, 64);
 				const auto dist = blockCenter.getDistance(Position(mainChoke->Center()));
 				if (dist > distBest && canAddBlock(tile, 5, 4, true))
@@ -67,13 +67,13 @@ namespace BWEB
 				TilePosition tile(x, y);
 				if (!tile.isValid()) continue;
 
-				auto area = BWEM::Map::Instance().GetArea(tile);
+				auto area = map.GetArea(tile);
 				if (!area) continue;
 
 				// Check if we should mirror our blocks - TODO: Improve the decisions for these
 				auto mirrorHorizontal = false, mirrorVertical = false;
-				if (BWEM::Map::Instance().Center().x > mainPosition.x) mirrorHorizontal = true;
-				if (BWEM::Map::Instance().Center().y > mainPosition.y) mirrorVertical = true;
+				if (map.Center().x > mainPosition.x) mirrorHorizontal = true;
+				if (map.Center().y > mainPosition.y) mirrorVertical = true;
 
 				if (Broodwar->self()->getRace() == Races::Protoss)
 				{
@@ -139,10 +139,10 @@ namespace BWEB
 		TilePosition four(here.x + width - 1, here.y + height - 1);
 
 		if (!one.isValid() || !two.isValid() || !three.isValid() || !four.isValid()) return false;
-		if (!BWEM::Map::Instance().GetTile(one).Buildable() || overlapsAnything(one)) return false;
-		if (!BWEM::Map::Instance().GetTile(two).Buildable() || overlapsAnything(two)) return false;
-		if (!BWEM::Map::Instance().GetTile(three).Buildable() || overlapsAnything(three)) return false;
-		if (!BWEM::Map::Instance().GetTile(four).Buildable() || overlapsAnything(four)) return false;
+		if (!map.GetTile(one).Buildable() || overlapsAnything(one)) return false;
+		if (!map.GetTile(two).Buildable() || overlapsAnything(two)) return false;
+		if (!map.GetTile(three).Buildable() || overlapsAnything(three)) return false;
+		if (!map.GetTile(four).Buildable() || overlapsAnything(four)) return false;
 
 		const auto offset = lowReq ? 0 : 1;
 		// Check if a block of specified size would overlap any bases, resources or other blocks
@@ -153,7 +153,7 @@ namespace BWEB
 				TilePosition tile(x, y);
 				if (tile == one || tile == two || tile == three || tile == four) continue;
 				if (!tile.isValid()) return false;
-				if (!BWEM::Map::Instance().GetTile(TilePosition(x, y)).Buildable()) return false;
+				if (!map.GetTile(TilePosition(x, y)).Buildable()) return false;
 				if (overlapGrid[x][y] > 0) return false;
 			}
 		}

--- a/Station.cpp
+++ b/Station.cpp
@@ -11,7 +11,7 @@ namespace BWEB
 
 	void Map::findStations()
 	{
-		for (auto& area : BWEM::Map::Instance().Areas())
+		for (auto& area : map.Areas())
 		{
 			for (auto& base : area.Bases())
 			{

--- a/Wall.cpp
+++ b/Wall.cpp
@@ -43,7 +43,7 @@ namespace BWEB
 			for (auto& tile : currentPath)
 			{
 				reserveGrid[tile.x][tile.y] = 1;
-				if (!BWEM::Map::Instance().GetArea(tile))
+				if (!map.GetArea(tile))
 					newWall.setWallDoor(tile);
 			}
 		}
@@ -258,7 +258,7 @@ namespace BWEB
 
 		// Reset hole and get a new path
 		currentHole = TilePositions::None;
-		currentPath = AStar().findPath(startTile, endTile, true);
+		currentPath = AStar().findPath(map, *this, startTile, endTile, true);
 		currentPathSize = static_cast<double>(currentPath.size());
 
 		// Quick check to see if the path contains our end point
@@ -324,7 +324,7 @@ namespace BWEB
 
 				const auto dist = center.getDistance(hold);
 
-				if (BWEM::Map::Instance().GetArea(TilePosition(center)) != wall.getArea()) continue;
+				if (map.GetArea(TilePosition(center)) != wall.getArea()) continue;
 				if (p.getDistance(Position(endTile)) < wall.getCentroid().getDistance(Position(endTile))) continue;
 
 				if (dist < distance)
@@ -497,7 +497,7 @@ namespace BWEB
 	void Map::setStartTile()
 	{
 		auto distBest = DBL_MAX;
-		if (!BWEM::Map::Instance().GetArea(startTile) || !isWalkable(startTile))
+		if (!map.GetArea(startTile) || !isWalkable(startTile))
 		{
 			for (auto x = startTile.x - 2; x < startTile.x + 2; x++)
 			{
@@ -506,7 +506,7 @@ namespace BWEB
 					TilePosition t(x, y);
 					const auto dist = t.getDistance(endTile);
 					if (overlapsCurrentWall(t) != UnitTypes::None) continue;
-					if (BWEM::Map::Instance().GetArea(t) == area && dist < distBest)
+					if (map.GetArea(t) == area && dist < distBest)
 						startTile = TilePosition(x, y), distBest = dist;
 				}
 			}
@@ -516,7 +516,7 @@ namespace BWEB
 	void Map::setEndTile()
 	{
 		auto distBest = 0.0;
-		if (!BWEM::Map::Instance().GetArea(endTile) || !isWalkable(endTile))
+		if (!map.GetArea(endTile) || !isWalkable(endTile))
 		{
 			for (auto x = endTile.x - 2; x < endTile.x + 2; x++)
 			{
@@ -525,7 +525,7 @@ namespace BWEB
 					TilePosition t(x, y);
 					const auto dist = t.getDistance(startTile);
 					if (overlapsCurrentWall(t) != UnitTypes::None) continue;
-					if (BWEM::Map::Instance().GetArea(t) && dist > distBest)
+					if (map.GetArea(t) && dist > distBest)
 						endTile = TilePosition(x, y), distBest = dist;
 				}
 			}


### PR DESCRIPTION
The reliance on the static instance of the BWEM is convinient during development,
but when doing testing not so much.
Maybe multiple instance of BWEM right now don't possible,
but if my testing related changes would be accepted and would be any issues
I will go and beg, please, send PR to make testing of BWEM happens

This namespace contains functions which could be used for backward
compatibility with existing code. Just put
`using namespace BWEB::Utils`
at the beginning of the file where static Map methods was used
and replace all usages of `Map::overlapsBlocks` with just `overlapsBlocks`
Alternatively explicit using `BWEB::Utils::overlapBlocks` could be used.

One of the changes related to #11