### PR TITLE
Use system lib include

### DIFF
--- a/BWEB.h
+++ b/BWEB.h
@@ -3,7 +3,7 @@
 #include <set>
 
 #include <BWAPI.h>
-#include "..\BWEM\bwem.h"
+#include <bwem.h>
 #include "Station.h"
 #include "Block.h"
 #include "Wall.h"


### PR DESCRIPTION
It is make sense to don't depend on specific dir structure
Right now looks like BWEB and BWEM should be in same parent directory, which is not required.
It is better setup VS/CMake settings depending on your environment.